### PR TITLE
Fixes typo in ChefDK download url and adds eof char.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wizeline GDL DevOps meetup demo
 
 ## Prerequesites
- - Install ChefDK (https://downloas.chef.io/chefdk)
+ - Install ChefDK (https://downloads.chef.io/chefdk)
  - Install Vagrant (https://www.vagrantup.com/downloads.html)
  - Install Virtualbox (https://www.virtualbox.org/wiki/Downloads)
 


### PR DESCRIPTION
There is a typo in the ChefDK download url and the end of file char was missing.